### PR TITLE
HDFS-17794 Documentation for dfs.datanode.synconclose

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/resources/hdfs-default.xml
@@ -1780,6 +1780,21 @@
 </property>
 
 <property>
+  <name>dfs.datanode.synconclose</name>
+  <value>false</value>
+  <description>
+        If this configuration is enabled, the datanode will instruct the
+        operating system to sync data block files contents to disk when the
+        blockfile is closed.
+
+        This has the benefit of ensuring that data is written to disk
+        immeditately when a block is closed, avoiding the data being held
+        in the operating system cache. This can help data loss in the event
+        of a malfunction such as a power failure.
+  </description>
+</property>
+
+<property>
   <name>dfs.client.failover.max.attempts</name>
   <value>15</value>
   <description>


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR
The HDFS configuration property dfs.datanode.synconclose is absent from the hdfs-site.xml documentation. This PR adds and entry in hdfs-default.xml for this property along with a description of its purpose.

### How was this patch tested?
Documentation only, no additional testing performed.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

